### PR TITLE
Remove `_POSIX_C_SOURCE` macro since `fmemopen` is no longer used

### DIFF
--- a/monitors/c/src/internals/config.h
+++ b/monitors/c/src/internals/config.h
@@ -7,9 +7,6 @@
     #error R2U2 requires C99 or higher
 #endif
 
-/* Enable POSIX.1 complaint fmemopen in stdio.h when building with -std=c99. */
-#define _POSIX_C_SOURCE 200112L
-
 #define R2U2_C_VERSION_MAJOR 4
 #define R2U2_C_VERSION_MINOR 1
 #define R2U2_C_VERSION_PATCH 0


### PR DESCRIPTION
Closes #54 